### PR TITLE
fix(github actions): add permissions to bump version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   tagging:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
ref: https://github.com/MH4GF/dependency-cruiser-report-action/actions/runs/3821329746/jobs/6500367333
