### PR TITLE
fix: Remove packageManager field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,5 @@
     "prettier": "^2.8.8",
     "typescript": "^5.1.6",
     "vitest": "^0.32.0"
-  },
-  "packageManager": "pnpm@8.6.5"
+  }
 }


### PR DESCRIPTION
The following job is failing:

```
/usr/local/bin/yarn run -s depcruise --output-type mermaid --config .dependency-cruiser.js --focus ^test/bun-workspace/.dependency-cruiser.cjs|^test/bun-workspace/index.js|^test/bun-workspace/packages/foo/index.js|^dist/index.js|^src/installDependencies.ts|^src/options/validateOptions.test.ts|^src/options/validateOptions.ts test/bun-workspace/.dependency-cruiser.cjs test/bun-workspace/index.js test/bun-workspace/packages/foo/index.js dist/index.js src/installDependencies.ts src/options/validateOptions.test.ts src/options/validateOptions.ts
error This project's package.json defines "packageManager": "yarn@pnpm@8.6.5". However the current global version of Yarn is 1.22.21.

Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.9 and 14.19.
Corepack must currently be enabled by running corepack enable in your terminal. For more information, check out https://yarnpkg.com/corepack.
Error: The process '/usr/local/bin/yarn' failed with exit code 1
```
https://github.com/MH4GF/dependency-cruiser-report-action/actions/runs/6956926445/job/18950886827?pr=274

Starting with yarn 1.22.21, it appears that the error occurs when another package manager is specified for packageManager.

- ref: https://github.com/yarnpkg/yarn/issues/9015

This field was added for corepack use in local development, but this project is not frequently maintained and should be left unconfigured.