### PR TITLE
Release for v2.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v2.5.3](https://github.com/MH4GF/dependency-cruiser-report-action/compare/v2.5.2...v2.5.3) - 2025-01-06
+### Other Changes
+- maintenance by @MH4GF in https://github.com/MH4GF/dependency-cruiser-report-action/pull/383
+
 ## [v2.5.2](https://github.com/MH4GF/dependency-cruiser-report-action/compare/v2.5.1...v2.5.2) - 2025-01-06
 ### Maintenance 👨‍💻
 - chore(deps): update all devdependencies by @renovate in https://github.com/MH4GF/dependency-cruiser-report-action/pull/365

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser-report-action",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "description": "visualize dependenices of changed files in each pull request.",
   "keywords": ["actions", "node", "setup"],


### PR DESCRIPTION
This pull request is for the next release as v2.5.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v2.5.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v2.5.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Other Changes
* maintenance by @MH4GF in https://github.com/MH4GF/dependency-cruiser-report-action/pull/383


**Full Changelog**: https://github.com/MH4GF/dependency-cruiser-report-action/compare/v2.5.2...v2.5.3