### PR TITLE
Release for v2.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [v2.5.4](https://github.com/MH4GF/dependency-cruiser-report-action/compare/v2.5.3...v2.5.4) - 2026-06-01
+### Maintenance 👨‍💻
+- chore(deps): update all devdependencies by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/387
+- chore(deps): update songmu/tagpr action to v1.5.1 by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/386
+- chore(deps): update dependency vitest to v2.1.9 [security] by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/388
+- chore(deps): update all devdependencies by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/389
+- chore(deps): update all devdependencies by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/393
+- chore(deps): update all devdependencies (major) by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/400
+- chore(deps): update all devdependencies by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/396
+- chore(deps): update dependency dependency-cruiser to v16.10.4 by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/398
+- chore(deps): update dependency dependency-cruiser to v17 by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/401
+- chore(deps): update all dependencies (github-actions) (major) by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/402
+- chore(deps): update node.js to v22.22.1 by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/399
+- chore(deps): update songmu/tagpr action to v1.17.1 by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/395
+- chore(deps): update node.js to v24 by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/404
+- fix(deps): update all dependencies by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/397
+- chore(deps): update all devdependencies by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/407
+- chore(deps): update all devdependencies by @renovate[bot] in https://github.com/MH4GF/dependency-cruiser-report-action/pull/408
+
 ## [v2.5.3](https://github.com/MH4GF/dependency-cruiser-report-action/compare/v2.5.2...v2.5.3) - 2025-01-06
 ### Other Changes
 - maintenance by @MH4GF in https://github.com/MH4GF/dependency-cruiser-report-action/pull/383

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-cruiser-report-action",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "private": true,
   "description": "visualize dependenices of changed files in each pull request.",
   "keywords": [


### PR DESCRIPTION
This pull request is for the next release as v2.5.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v2.5.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v2.5.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---

## What's Changed
### Maintenance 👨‍💻
* chore(deps): update all devdependencies by @renovate in https://github.com/MH4GF/dependency-cruiser-report-action/pull/387
* chore(deps): update songmu/tagpr action to v1.5.1 by @renovate in https://github.com/MH4GF/dependency-cruiser-report-action/pull/386
* chore(deps): update dependency vitest to v2.1.9 [security] by @renovate in https://github.com/MH4GF/dependency-cruiser-report-action/pull/388
* chore(deps): update all devdependencies by @renovate in https://github.com/MH4GF/dependency-cruiser-report-action/pull/389
* chore(deps): update all devdependencies by @renovate in https://github.com/MH4GF/dependency-cruiser-report-action/pull/393
* chore(deps): update all devdependencies by @renovate in https://github.com/MH4GF/dependency-cruiser-report-action/pull/396
* chore(deps): update dependency dependency-cruiser to v16.10.4 by @renovate in https://github.com/MH4GF/dependency-cruiser-report-action/pull/398
* chore(deps): update all devdependencies (major) by @renovate in https://github.com/MH4GF/dependency-cruiser-report-action/pull/400
* chore(deps): update dependency dependency-cruiser to v17 by @renovate in https://github.com/MH4GF/dependency-cruiser-report-action/pull/401

**Full Changelog**: https://github.com/MH4GF/dependency-cruiser-report-action/compare/v2.5.3...v2.5.4
