### PR TITLE
fix(ci): skip the push in update-dist when dist is unchanged

### DIFF
--- a/.github/workflows/update-dist.yml
+++ b/.github/workflows/update-dist.yml
@@ -27,9 +27,13 @@ jobs:
         env:
           MH4GF_PAT: ${{ secrets.MH4GF_PAT }}
         run: |
+          git add .
+          if git diff --staged --quiet; then
+            echo "dist is up to date"
+            exit 0
+          fi
           git remote set-url origin https://x-access-token:${MH4GF_PAT}@github.com/${GITHUB_REPOSITORY}
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git diff --staged --quiet || git commit -m 'update dist'
+          git commit -m 'update dist'
           git push


### PR DESCRIPTION
## 問題

`update-dist` は必須ステータスチェックだが、現在 open な依存更新 PR **7 件すべて**で失敗しており、全部が BLOCKED になっている。

失敗原因は `MH4GF_PAT` の失効:

```
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/MH4GF/dependency-cruiser-report-action/'
##[error]Process completed with exit code 128.
```

## 根本原因

`git push` が `git diff --staged --quiet` のガードの**外**にあり、無条件に実行されていた。

```bash
git add .
git diff --staged --quiet || git commit -m 'update dist'
git push   # ← 差分ゼロでも必ず走る
```

`main` で `pnpm package` を実行しても `dist/` に差分は出ない（検証済み）。つまり workflow ファイルや依存のみを触る PR では **push するものが何もない**。それでも `git push` が実行され、失効した PAT で認証エラーになり、ジョブが exit 128 で落ちていた。

ジョブが必要としていない資格情報のせいで、7 件の PR が止まっていたことになる。

## 修正

作業ツリーがクリーンなら早期リターンし、実際に push する経路でのみリモートの資格情報を触るようにした。

これで dist に変更のない PR は PAT なしで green になる。dist が実際に変わる PR では引き続き有効な `MH4GF_PAT` が必要なので、その場合は secret のローテーションが別途必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)